### PR TITLE
Autoredirect

### DIFF
--- a/lib/twitter_client.js
+++ b/lib/twitter_client.js
@@ -22,7 +22,7 @@ module.exports = function (api_key, api_secret, redirect) {
         api_key,
         api_secret,
         '1.0',
-        redirect,
+        redirect || false,
         'HMAC-SHA1',
         null,
         {'Accept': '*/*', 'Connection': 'close', 'User-Agent': 'twitter-js ' + client.version}
@@ -66,7 +66,9 @@ module.exports = function (api_key, api_secret, redirect) {
 
   client.getAccessToken = function (req, res, callback) {
 
-    var parsedUrl = url.parse(req.url, true);
+    var parsedUrl = url.parse(req.url, true)
+      , protocol = (req.socket.encrypted ? 'https' : 'http' )
+      , callbackUrl = protocol + '://' + req.headers.host + parsedUrl.pathname;
 
     // Acces token
     if (parsedUrl.query && parsedUrl.query.oauth_token && req.session.auth && req.session.auth.twitter_oauth_token_secret) {
@@ -88,6 +90,7 @@ module.exports = function (api_key, api_secret, redirect) {
     } else {
 
       oAuth.getOAuthRequestToken(
+        { oauth_callback: callbackUrl },
         function (error, oauth_token, oauth_token_secret, oauth_authorize_url, additionalParameters) {
           if (!error) {
             req.session.twitter_redirect_url = req.url;


### PR DESCRIPTION
There didn't seem to be any reason to specify the redirect url in initialization, as you know the hostname and path when you make the request.  Also, it was annoying me because I'd have to change it (or use an environment variable) when I switched my code from development to production. :-)

This change takes the protocol / host / port / path from the request that loads the getAccessToken request and uses that for the redirect url (which works really well because the API already requires that you redirecting back to that route).

Note the change is backward compatible, you can still specify the final url if you want (though I don't know why you would).
