### PR TITLE
seems to work fine with 0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,5 +8,5 @@
   "directories" : { "lib" : "./lib" },
   "dependencies": { "oauth": ">= 0.8.2" },
   "repository" : {"type": "git" , "url": "http://github.com/masylum/twitter-js.git" },
-  "engines": { "node": ">=0.2.0 <0.3.0" }
+  "engines": { "node": ">=0.2.0 <0.5.0" }
 }


### PR DESCRIPTION
was there a reason the <0.3 dependency was added? from my testing, everything works fine on 0.4. tested on 0.4.1, 0.4.4, and 0.4.5.
